### PR TITLE
Use of Void for void closures

### DIFF
--- a/JustPeek/Classes/PeekView.swift
+++ b/JustPeek/Classes/PeekView.swift
@@ -27,9 +27,9 @@ internal class PeekView: UIView {
         layer.cornerRadius = cornerRadiusFor(frame: frame)
     }
     
-    func animateToFrame(_ frame: CGRect, alongsideAnimation otherAnimation: (() -> ())? = nil, completion: ((Bool) -> ())? = nil) {
+    func animateToFrame(_ frame: CGRect, alongsideAnimation otherAnimation: (() -> Void)? = nil, completion: ((Bool) -> Void)? = nil) {
         layoutIfNeeded()
-        let animations: () -> () = { [weak self] in
+        let animations: () -> Void = { [weak self] in
             if let strongSelf = self {
                 otherAnimation?()
                 strongSelf.frame = frame

--- a/JustPeek/Classes/PeekViewController.swift
+++ b/JustPeek/Classes/PeekViewController.swift
@@ -34,11 +34,11 @@ internal class PeekViewController: UIViewController {
         fatalError("init(coder:) must not be used")
     }
     
-    internal func peek(_ completion: ((Bool) -> ())? = nil) {
+    internal func peek(_ completion: ((Bool) -> Void)? = nil) {
         animatePeekView(true, completion: completion)
     }
     
-    internal func pop(_ completion: ((Bool) -> ())?) {
+    internal func pop(_ completion: ((Bool) -> Void)?) {
         animatePeekView(false, completion: completion)
     }
     
@@ -46,7 +46,7 @@ internal class PeekViewController: UIViewController {
         return self.view.convert(peekContext.initalPreviewFrame(), from: peekContext.sourceView)
     }
     
-    fileprivate func animatePeekView(_ forBeingPresented: Bool, completion: ((Bool) -> ())?) {
+    fileprivate func animatePeekView(_ forBeingPresented: Bool, completion: ((Bool) -> Void)?) {
         let destinationFrame = forBeingPresented ? peekContext.finalPreviewFrame() : convertedInitialFrame()
         contentView.alpha = forBeingPresented ? 0.0 : 1.0
         let contentViewAnimation = { [weak self] in


### PR DESCRIPTION
With this commit all void closures `()` replaced with a better syntax standard Void.